### PR TITLE
 【更新】Keycloak v26 対応とプロフィール画像対応 #52 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .project
 .classpath
 .settings
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
 
     <groupId>org.keycloak.extensions</groupId>
     <artifactId>keycloak-discord</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
-        <version.keycloak>22.0.1</version.keycloak>
+        <version.keycloak>26.0.2</version.keycloak>
     </properties>
 
     <dependencies>
@@ -48,8 +48,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>24</source>
+                    <target>24</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
+++ b/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
@@ -72,7 +72,7 @@ public class DiscordIdentityProvider extends AbstractOAuth2IdentityProvider<Disc
 
         user.setUsername(getJsonProperty(profile, "username"));
         user.setEmail(getJsonProperty(profile, "email"));
-        user.setUserAttribute("profile_icon",
+        user.setUserAttribute("picture",
                 "https://cdn.discordapp.com/" + getJsonProperty(profile, "avatar") + ".png?size=512");
         user.setIdp(this);
 

--- a/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
+++ b/src/main/java/org/keycloak/social/discord/DiscordIdentityProvider.java
@@ -73,7 +73,8 @@ public class DiscordIdentityProvider extends AbstractOAuth2IdentityProvider<Disc
         user.setUsername(getJsonProperty(profile, "username"));
         user.setEmail(getJsonProperty(profile, "email"));
         user.setUserAttribute("picture",
-                "https://cdn.discordapp.com/" + getJsonProperty(profile, "avatar") + ".png?size=512");
+                "https://cdn.discordapp.com/avatars/" + getJsonProperty(profile, "id") + "/"
+                        + getJsonProperty(profile, "avatar") + ".png?size=512");
         user.setIdp(this);
 
         AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, profile, getConfig().getAlias());


### PR DESCRIPTION
## 変更点
- `extractIdentityFromProfile`関数に変更が少しあり
- Picture属性を追加することでプロフィール画像の表示を可能にした

## 動作確認
- Keycloak v26.0 (Docker)